### PR TITLE
Add Centos 8 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
       matrix:
         os:
           - 'centos-7'
+          - 'centos-8'
           - 'debian-9'
           - 'ubuntu-1604'
           - 'ubuntu-1804'

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This cookbook is maintained by the Sous Chefs. The Sous Chefs are a community of
 - Debian 8+
 - Ubuntu 16.04+
 - RHEL 6.x and 7.x w/ (EPEL is enabled as required)
-- CentOS 6.x, 7.x
+- CentOS 6.x, 7.x, 8.x
 - Fedora
 - OpenSUSE 42+ (partial support/WIP)
 - Arch Linux

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -10,6 +10,7 @@ transport:
 
 provisioner:
   name: dokken
+  chef_license: accept-no-persist
 
 verifier:
   name: inspec
@@ -41,6 +42,11 @@ platforms:
   - name: centos-7
     driver:
       image: dokken/centos-7
+      pid_one_command: /usr/lib/systemd/systemd
+
+  - name: centos-8
+    driver:
+      image: dokken/centos-8
       pid_one_command: /usr/lib/systemd/systemd
 
   - name: fedora-latest

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -21,7 +21,12 @@ include_recipe 'openvpn::install'
 # systemd platforms use an instance service
 case node['platform_family']
 when 'rhel'
-  if node['platform_version'] >= '7'
+  if node['platform_version'] >= '8'
+    link "/etc/systemd/system/multi-user.target.wants/openvpn-#{node['openvpn']['type']}@#{node['openvpn']['type']}.service" do
+      to '/usr/lib/systemd/system/openvpn@.service'
+    end
+    service_name = "openvpn-#{node['openvpn']['type']}@#{node['openvpn']['type']}.service"
+  elsif node['platform_version'] >= '7'
     link "/etc/systemd/system/multi-user.target.wants/openvpn@#{node['openvpn']['type']}.service" do
       to '/usr/lib/systemd/system/openvpn@.service'
     end

--- a/resources/conf.rb
+++ b/resources/conf.rb
@@ -29,7 +29,13 @@ action :create do
                       "#{new_resource.name}.conf.erb"
                     end
 
-  template [node['openvpn']['fs_prefix'], "/etc/openvpn/#{new_resource.name}.conf"].join do
+  conf_location = if platform_family?('rhel') && node['platform_version'] >= '8'
+                    "/etc/openvpn/#{new_resource.name}/#{new_resource.name}.conf"
+                  else
+                    "/etc/openvpn/#{new_resource.name}.conf"
+                  end
+
+  template [node['openvpn']['fs_prefix'], "#{conf_location}"].join do
     cookbook new_resource.cookbook
     source template_source
     owner 'root'
@@ -60,7 +66,7 @@ action :create do
 end
 
 action :delete do
-  file [node['openvpn']['fs_prefix'], "/etc/openvpn/#{new_resource.name}.conf"].join do
+  file [node['openvpn']['fs_prefix'], "#{conf_location}"].join do
     action :delete
   end
 end

--- a/test/integration/server/server_test.rb
+++ b/test/integration/server/server_test.rb
@@ -2,11 +2,16 @@
 # https://github.com/xhost-cookbooks/openvpn/blob/master/recipes/service.rb
 
 if (os[:name] == 'redhat' && os[:release] >= '7') ||
-   (os[:name] == 'centos' && os[:release] >= '7') ||
+   (os[:name] == 'centos' && os[:release] < '8') ||
    (os[:name] == 'debian' && os[:release] >= '8') ||
    (os[:name] == 'ubuntu' && os[:release] >= '15.04') ||
    (os[:name] == 'fedora')
   describe service('openvpn@server') do
+    it { is_expected.to be_enabled }
+    it { is_expected.to be_running }
+  end
+elsif os[:name] == 'centos' && os[:release] >= '8'
+  describe service('openvpn-server@server') do
     it { is_expected.to be_enabled }
     it { is_expected.to be_running }
   end
@@ -17,7 +22,13 @@ else
   end
 end
 
-describe file('/etc/openvpn/server.conf') do
+conf_location = if os[:name] == 'centos' && os[:release] >= '8'
+                  '/etc/openvpn/server/server.conf'
+                else
+                  '/etc/openvpn/server.conf'
+                end
+
+describe file("#{conf_location}") do
   its('content') { should include 'push "dhcp-option DOMAIN local"' }
   its('content') { should include 'push "dhcp-option DOMAIN-SEARCH local"' }
   its('content') { should include 'push "route 192.168.10.0 255.255.255.0"' }


### PR DESCRIPTION
### Description

Adds support for CentOS 8.

### Issues Resolved

- The default OpenVPN configuration location has changed from `/etc/openvpn/<type>.conf` to `/etc/openvpn/<type>/<type>.conf` in CentOS 8.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>

- [x] New functionality includes testing.

- [x] New functionality has been documented in the README if applicable
